### PR TITLE
add representation header to delete options

### DIFF
--- a/src/postgrest.js
+++ b/src/postgrest.js
@@ -174,7 +174,7 @@ function Postgrest () {
                   },
 
                   deleteOptions = (filters, options, headers = {}) => {
-                      const extraHeaders = addHeaders(_.extend({}, headers));
+                      const extraHeaders = _.extend({}, representationHeader, headers);
                       return querystring(filters, addConfigHeaders(extraHeaders, _.extend({}, options, nameOptions, {
                           method: 'DELETE'
                       })));


### PR DESCRIPTION
```m.request``` requires a valid json being returned, without this header we return a empty body which is invalid.